### PR TITLE
Enhance node saml

### DIFF
--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -55,38 +55,108 @@ function getNameFormat(name){
   return 'urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified';
 }
 
-exports.create = function(options, callback) {
-  if (!options.key)
-    throw new Error('Expect a private key in pem format');
+/**
+* Gets the complere SAML Response merged with assertion (encrypted optional) and uses the
+* saml20 argument options to set parts of the response utilizing the saml20Response.template file.
+* @param assertion - the SAML assertion to add to the SAML response.
+* @param options - The saml20 class options argument.
+*/
+function getSamlResponseXml(assertion, options) {
+  var issueTime = new Date().toISOString();
 
-  if (!options.cert)
-    throw new Error('Expect a public key cert in pem format');
+  var assertionXml = new Parser().parseFromString(assertion);
+  var saml20Response = fs.readFileSync(path.join(__dirname, 'saml20Response.template')).toString();
 
-  options.signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
-  options.digestAlgorithm = options.digestAlgorithm || 'sha256';
+  var doc = new Parser().parseFromString(saml20Response.toString());
 
-  options.includeAttributeNameFormat = (typeof options.includeAttributeNameFormat !== 'undefined') ? options.includeAttributeNameFormat : true;
-  options.typedAttributes = (typeof options.typedAttributes !== 'undefined') ? options.typedAttributes : true;
+  doc.documentElement.setAttribute('ID', '_' + (options.uid || utils.uid(32)));
+  doc.documentElement.setAttribute('IssueInstant', moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
+  doc.documentElement.setAttribute('Destination', options.destination);
+  if (options.issuer) {
+    var issuer = doc.documentElement.getElementsByTagName('saml:Issuer');
+    issuer[0].textContent = options.issuer;
+  }
+  doc.lastChild.appendChild(assertionXml.documentElement);
+  
+  return doc.toString();
+}
 
+/**
+* Signs the SAML XML at the Assertion level (default) or the Response Level (optional) using private key and cert.
+* @param xmlToSign - The XML in string form containing the XML assertion or response.
+* @param options - The saml20 class options argument.
+*/
+function signXml(xmlToSign, options) {
   // 0.10.1 added prefix, but we want to name it signatureNamespacePrefix - This is just to keep supporting prefix
   options.signatureNamespacePrefix = options.signatureNamespacePrefix || options.prefix;
   options.signatureNamespacePrefix = typeof options.signatureNamespacePrefix === 'string' ? options.signatureNamespacePrefix : '' ; 
 
   var cert = utils.pemToCert(options.cert);
-
   var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[options.signatureAlgorithm], idAttribute: 'ID' });
-  sig.addReference("//*[local-name(.)='Assertion']",
-                  ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
-                  algorithms.digest[options.digestAlgorithm]);
+  var signingLocation = options.createSignedSamlResponse ? 'Response' : 'Assertion';
+  sig.addReference("//*[local-name(.)='" + signingLocation + "']",
+    ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
+    algorithms.digest[options.digestAlgorithm]);
 
   sig.signingKey = options.key;
-  
+
+  var opts = {
+    location: {
+      reference: options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']",
+      action: 'after'
+    },
+    prefix: options.signatureNamespacePrefix
+  };
+
   sig.keyInfoProvider = {
     getKeyInfo: function (key, prefix) {
       prefix = prefix ? prefix + ':' : prefix;
       return "<" + prefix + "X509Data><" + prefix + "X509Certificate>" + cert + "</" + prefix + "X509Certificate></" + prefix + "X509Data>";
     }
   };
+
+  sig.computeSignature(xmlToSign, opts);
+
+  return sig.getSignedXml();
+}
+
+/**
+* Encrypts s SAML assertion and formats with EncryptedAssertion wrapper using provided cert.
+* @param assertionToEncrypt - The SAML assertion to encrypt.
+* @param options - The saml20 class options argument.
+* @param callback - The callback function for ASYNC processing completion.
+*/
+function encryptAssertionXml(assertionToEncrypt, options, callback) {
+  var encryptOptions = {
+    rsa_pub: options.encryptionPublicKey,
+    pem: options.encryptionCert,
+    encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
+    keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
+  };
+  
+  xmlenc.encrypt(assertionToEncrypt, encryptOptions, function (err, encrypted) {
+    if (err) return callback(err);
+    var assertion = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
+    return callback(null, assertion);
+  })
+}
+
+exports.create = function (options, callback) {
+  if (!options.key)
+    throw new Error('Expect a private key in pem format');
+
+  if (!options.cert)
+    throw new Error('Expect a public key cert in pem format');
+
+  if (options.createSignedSamlResponse &&
+       (!options.destination || options.destination.length < 1))
+    throw new Error('Expect a SAML Response destination for message to be valid.')
+
+  options.signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
+  options.digestAlgorithm = options.digestAlgorithm || 'sha256';
+
+  options.includeAttributeNameFormat = (typeof options.includeAttributeNameFormat !== 'undefined') ? options.includeAttributeNameFormat : true;
+  options.typedAttributes = (typeof options.typedAttributes !== 'undefined') ? options.typedAttributes : true;
 
   var doc;
   try {
@@ -184,48 +254,54 @@ exports.create = function(options, callback) {
   if (options.nameIdentifierFormat) {
     nameID.setAttribute('Format', options.nameIdentifierFormat);
   }
-  
+
   if( options.authnContextClassRef ) {
     var authnCtxClassRef = doc.getElementsByTagName('saml:AuthnContextClassRef')[0];
     authnCtxClassRef.textContent = options.authnContextClassRef;
   }
 
-  var token = utils.removeWhitespace(doc.toString());
-  var signed;
-  try {
-    var opts = { 
-      location: { 
-        reference: options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']", 
-        action: 'after'
-      },
-      prefix: options.signatureNamespacePrefix
-    };
-    
-    sig.computeSignature(token, opts);
-    signed = sig.getSignedXml();
-  } catch(err){
-    return utils.reportError(err, callback);
+  var assertion = utils.removeWhitespace(doc.toString());
+
+  // NEW: Option: build a complete signed SAML response with embedded (option encrypted) assertion
+  if (options.createSignedSamlResponse) {
+    try {
+      // IF SAML response assertion is set to be encrypted
+      if (options.encryptionCert) {
+        encryptAssertionXml(assertion, options, function (err, encryptedAssertion) {
+          if (err) return callback(err);
+          var signedResponse = signSamlResponse(encryptedAssertion);
+          return callback(null, signedResponse);
+        });
+      } else {
+        // Do not encrypt assertion and send back
+        var signedPlainResponse = signSamlResponse(assertion);
+        return (callback) ? callback(null, signedPlainResponse) : signedPlainResponse;
+      }
+    } catch (err) {
+      return (callback) ? callback(err) : err;
+    }
+  } else {
+    try {
+      // Sign the assertion always for both options
+      var signedAssertion = signXml(utils.removeWhitespace(assertion), options);
+      if (options.encryptionCert) {
+        // If assertion is set to be encrypted
+        encryptAssertionXml(signedAssertion, options, function (err, encryptedAssertion) {
+          if (err) return callback(err);
+          return callback(null, encryptedAssertion)
+        });
+      } else {
+        // If assertion encryption not set just send back
+        return (callback) ? callback(null, signedAssertion) : signedAssertion;
+      }
+    } catch (err) {
+      return (callback) ? callback(err) : err;
+    }
   }
 
-  if (!options.encryptionCert) {
-    if (callback) 
-      return callback(null, signed);
-    else 
-      return signed;
+  // Generates response with inserted assertion (or encrypted assertion) and signs
+  function signSamlResponse(assertion) {
+    var samlResponse = getSamlResponseXml(assertion, options);
+    return signXml(utils.removeWhitespace(samlResponse), options);
   }
-
-  var encryptOptions = {
-    rsa_pub: options.encryptionPublicKey,
-    pem: options.encryptionCert,
-    encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-    keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-  };
-
-  xmlenc.encrypt(signed, encryptOptions, function(err, encrypted) {
-    if (err) return callback(err);
-    
-    encrypted = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
-    callback(null, utils.removeWhitespace(encrypted));
-  });
-}; 
-
+};

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -1,11 +1,11 @@
 
 var utils = require('./utils'),
-  Parser = require('xmldom').DOMParser,
-  SignedXml = require('xml-crypto').SignedXml,
-  xmlenc = require('xml-encryption'),
-  moment = require('moment'),
-  xmlNameValidator = require('xml-name-validator'),
-  is_uri = require('valid-url').is_uri;
+    Parser = require('xmldom').DOMParser,
+    SignedXml = require('xml-crypto').SignedXml,
+    xmlenc = require('xml-encryption'),
+    moment = require('moment'),
+    xmlNameValidator = require('xml-name-validator'),
+    is_uri = require('valid-url').is_uri;
 
 var fs = require('fs');
 var path = require('path');
@@ -16,7 +16,7 @@ var NAMESPACE = 'urn:oasis:names:tc:SAML:2.0:assertion';
 var algorithms = {
   signature: {
     'rsa-sha256': 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
-    'rsa-sha1': 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+    'rsa-sha1':  'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
   },
   digest: {
     'sha256': 'http://www.w3.org/2001/04/xmlenc#sha256',
@@ -24,8 +24,8 @@ var algorithms = {
   }
 };
 
-function getAttributeType(value) {
-  switch (typeof value) {
+function getAttributeType(value){
+  switch(typeof value) {
     case "string":
       return 'xs:string';
     case "boolean":
@@ -38,16 +38,16 @@ function getAttributeType(value) {
   }
 }
 
-function getNameFormat(name) {
-  if (is_uri(name)) {
+function getNameFormat(name){
+  if (is_uri(name)){
     return 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri';
   }
 
   //  Check that the name is a valid xs:Name -> https://www.w3.org/TR/xmlschema-2/#Name
-  //  xmlNameValidate.name takes a string and will return an object of the form { success, error },
-  //  where success is a boolean
+  //  xmlNameValidate.name takes a string and will return an object of the form { success, error }, 
+  //  where success is a boolean 
   //  if it is false, then error is a string containing some hint as to where the match went wrong.
-  if (xmlNameValidator.name(name).success) {
+  if (xmlNameValidator.name(name).success){
     return 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic';
   }
 
@@ -55,102 +55,12 @@ function getNameFormat(name) {
   return 'urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified';
 }
 
-/**
-* Gets the complere SAML Response merged with assertion (encrypted optional) and uses the
-* saml20 argument options to set parts of the response utilizing the saml20Response.template file.
-* @param assertion - the SAML assertion to add to the SAML response.
-* @param options - The saml20 class options argument.
-*/
-function getSamlResponseXml(assertion, options) {
-  var issueTime = new Date().toISOString();
-
-  var assertionXml = new Parser().parseFromString(assertion);
-  var saml20Response = fs.readFileSync(path.join(__dirname, 'saml20Response.template')).toString();
-
-  var doc = new Parser().parseFromString(saml20Response.toString());
-
-  doc.documentElement.setAttribute('ID', '_' + (options.uid || utils.uid(32)));
-  doc.documentElement.setAttribute('IssueInstant', moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
-  doc.documentElement.setAttribute('Destination', options.destination);
-  if (options.issuer) {
-    var issuer = doc.documentElement.getElementsByTagName('saml:Issuer');
-    issuer[0].textContent = options.issuer;
-  }
-  doc.lastChild.appendChild(assertionXml.documentElement);
-
-  return doc.toString();
-}
-
-/**
-* Signs the SAML XML at the Assertion level (default) or the Response Level (optional) using private key and cert.
-* @param xmlToSign - The XML in string form containing the XML assertion or response.
-* @param options - The saml20 class options argument.
-*/
-function signXml(xmlToSign, options) {
-  // 0.10.1 added prefix, but we want to name it signatureNamespacePrefix - This is just to keep supporting prefix
-  options.signatureNamespacePrefix = options.signatureNamespacePrefix || options.prefix;
-  options.signatureNamespacePrefix = typeof options.signatureNamespacePrefix === 'string' ? options.signatureNamespacePrefix : '';
-
-  var cert = utils.pemToCert(options.cert);
-  var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[options.signatureAlgorithm], idAttribute: 'ID' });
-  var signingLocation = options.createSignedSamlResponse ? 'Response' : 'Assertion';
-  sig.addReference("//*[local-name(.)='" + signingLocation + "']",
-    ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
-    algorithms.digest[options.digestAlgorithm]);
-
-  sig.signingKey = options.key;
-
-  var opts = {
-    location: {
-      reference: options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']",
-      action: 'after'
-    },
-    prefix: options.signatureNamespacePrefix
-  };
-
-  sig.keyInfoProvider = {
-    getKeyInfo: function (key, prefix) {
-      prefix = prefix ? prefix + ':' : prefix;
-      return "<" + prefix + "X509Data><" + prefix + "X509Certificate>" + cert + "</" + prefix + "X509Certificate></" + prefix + "X509Data>";
-    }
-  };
-
-  sig.computeSignature(xmlToSign, opts);
-
-  return sig.getSignedXml();
-}
-
-/**
-* Encrypts s SAML assertion and formats with EncryptedAssertion wrapper using with provided cert.
-* @param assertionToEncrypt - The SAML assertion to encrypt.
-* @param options - The saml20 class options argument.
-* @param callback - The callback function for ASYNC processing completion.
-*/
-function encryptAssertionXml(assertionToEncrypt, options, callback) {
-  var encryptOptions = {
-    rsa_pub: options.encryptionPublicKey,
-    pem: options.encryptionCert,
-    encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-    keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-  };
-
-  xmlenc.encrypt(assertionToEncrypt, encryptOptions, function (err, encrypted) {
-    if (err) return callback(err);
-    var assertion = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
-    return callback(null, assertion);
-  })
-}
-
-exports.create = function (options, callback) {
+exports.create = function(options, callback) {
   if (!options.key)
     throw new Error('Expect a private key in pem format');
 
   if (!options.cert)
     throw new Error('Expect a public key cert in pem format');
-
-  if (options.createSignedSamlResponse &&
-       (!options.destination || options.destination.length < 1))
-    throw new Error('Expect a SAML Response destination for message to be valid.')
 
   options.signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
   options.digestAlgorithm = options.digestAlgorithm || 'sha256';
@@ -158,10 +68,30 @@ exports.create = function (options, callback) {
   options.includeAttributeNameFormat = (typeof options.includeAttributeNameFormat !== 'undefined') ? options.includeAttributeNameFormat : true;
   options.typedAttributes = (typeof options.typedAttributes !== 'undefined') ? options.typedAttributes : true;
 
+  // 0.10.1 added prefix, but we want to name it signatureNamespacePrefix - This is just to keep supporting prefix
+  options.signatureNamespacePrefix = options.signatureNamespacePrefix || options.prefix;
+  options.signatureNamespacePrefix = typeof options.signatureNamespacePrefix === 'string' ? options.signatureNamespacePrefix : '' ; 
+
+  var cert = utils.pemToCert(options.cert);
+
+  var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[options.signatureAlgorithm], idAttribute: 'ID' });
+  sig.addReference("//*[local-name(.)='Assertion']",
+                  ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
+                  algorithms.digest[options.digestAlgorithm]);
+
+  sig.signingKey = options.key;
+  
+  sig.keyInfoProvider = {
+    getKeyInfo: function (key, prefix) {
+      prefix = prefix ? prefix + ':' : prefix;
+      return "<" + prefix + "X509Data><" + prefix + "X509Certificate>" + cert + "</" + prefix + "X509Certificate></" + prefix + "X509Data>";
+    }
+  };
+
   var doc;
   try {
     doc = new Parser().parseFromString(saml20.toString());
-  } catch (err) {
+  } catch(err){
     return utils.reportError(err, callback);
   }
 
@@ -179,10 +109,10 @@ exports.create = function (options, callback) {
   if (options.lifetimeInSeconds) {
     conditions[0].setAttribute('NotBefore', now.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
     conditions[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
-
-    confirmationData[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
+  
+    confirmationData[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));  
   }
-
+  
   if (options.audiences) {
     var audienceRestriction = doc.createElementNS(NAMESPACE, 'saml:AudienceRestriction');
     var audiences = options.audiences instanceof Array ? options.audiences : [options.audiences];
@@ -192,7 +122,7 @@ exports.create = function (options, callback) {
       audienceRestriction.appendChild(element);
     });
 
-    conditions[0].appendChild(audienceRestriction);
+    conditions[0].appendChild(audienceRestriction); 
   }
 
   if (options.recipient)
@@ -206,16 +136,16 @@ exports.create = function (options, callback) {
     statement.setAttribute('xmlns:xs', 'http://www.w3.org/2001/XMLSchema');
     statement.setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
     doc.documentElement.appendChild(statement);
-    Object.keys(options.attributes).forEach(function (prop) {
-      if (typeof options.attributes[prop] === 'undefined') return;
+    Object.keys(options.attributes).forEach(function(prop) {
+      if(typeof options.attributes[prop] === 'undefined') return;
       // <saml:Attribute AttributeName="name" AttributeNamespace="http://schemas.xmlsoap.org/claims/identity">
       //    <saml:AttributeValue>Foo Bar</saml:AttributeValue>
       // </saml:Attribute>
       var attributeElement = doc.createElementNS(NAMESPACE, 'saml:Attribute');
       attributeElement.setAttribute('Name', prop);
 
-      if (options.includeAttributeNameFormat) {
-        attributeElement.setAttribute('NameFormat', getNameFormat(prop));
+      if (options.includeAttributeNameFormat){
+        attributeElement.setAttribute('NameFormat', getNameFormat(prop));        
       }
 
       var values = options.attributes[prop] instanceof Array ? options.attributes[prop] : [options.attributes[prop]];
@@ -230,7 +160,7 @@ exports.create = function (options, callback) {
         }
       });
 
-      if (values && values.filter(function (i) { return typeof i !== 'undefined'; }).length > 0) {
+      if (values && values.filter(function(i){ return typeof i !== 'undefined'; }).length > 0) {
         // saml:Attribute must have at least one saml:AttributeValue
         statement.appendChild(attributeElement);
       }
@@ -246,7 +176,7 @@ exports.create = function (options, callback) {
   }
 
   var nameID = doc.documentElement.getElementsByTagNameNS(NAMESPACE, 'NameID')[0];
-
+  
   if (options.nameIdentifier) {
     nameID.textContent = options.nameIdentifier;
   }
@@ -254,55 +184,48 @@ exports.create = function (options, callback) {
   if (options.nameIdentifierFormat) {
     nameID.setAttribute('Format', options.nameIdentifierFormat);
   }
-
-  if (options.authnContextClassRef) {
+  
+  if( options.authnContextClassRef ) {
     var authnCtxClassRef = doc.getElementsByTagName('saml:AuthnContextClassRef')[0];
     authnCtxClassRef.textContent = options.authnContextClassRef;
   }
 
-  var assertion = utils.removeWhitespace(doc.toString());
-
-  // NEW: Option: build a complete signed SAML response with embedded (option encrypted) assertion
-  if (options.createSignedSamlResponse) {
-    try {
-      // IF SAML response assertion is set to be encrypted
-      if (options.encryptionCert) {
-        encryptAssertionXml(assertion, options, function (err, encryptedAssertion) {
-          if (err) return callback(err);
-          var signedResponse = signSamlResponse(encryptedAssertion);
-          return callback(null, signedResponse);
-        });
-      } else {
-        // Do not encrypt assertion and send back
-        var signedPlainResponse = signSamlResponse(assertion);
-        return (callback) ? callback(null, signedPlainResponse) : signedPlainResponse;
-      }
-    } catch (err) {
-      return (callback) ? callback(err) : err;
-    }
-  } else {
-    try {
-      // Sign the assertion always for both options
-      var signedAssertion = signXml(utils.removeWhitespace(assertion), options);
-      if (options.encryptionCert) {
-        // If assertion is set to be encrypted
-        encryptAssertionXml(signedAssertion, options, function (err, encryptedAssertion) {
-          if (err) return callback(err);
-          return callback(null, encryptedAssertion)
-        });
-      } else {
-        // If assertion encryption not set just send back
-        return (callback) ? callback(null, signedAssertion) : signedAssertion;
-      }
-    } catch (err) {
-      return (callback) ? callback(err) : err;
-    }
+  var token = utils.removeWhitespace(doc.toString());
+  var signed;
+  try {
+    var opts = { 
+      location: { 
+        reference: options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']", 
+        action: 'after'
+      },
+      prefix: options.signatureNamespacePrefix
+    };
+    
+    sig.computeSignature(token, opts);
+    signed = sig.getSignedXml();
+  } catch(err){
+    return utils.reportError(err, callback);
   }
 
-  // Generates response with inserted assertion (or encrypted assertion) and signs
-  function signSamlResponse(assertion) {
-    var samlResponse = getSamlResponseXml(assertion, options);
-    return signXml(utils.removeWhitespace(samlResponse), options);
+  if (!options.encryptionCert) {
+    if (callback) 
+      return callback(null, signed);
+    else 
+      return signed;
   }
 
-};
+  var encryptOptions = {
+    rsa_pub: options.encryptionPublicKey,
+    pem: options.encryptionCert,
+    encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
+    keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
+  };
+
+  xmlenc.encrypt(signed, encryptOptions, function(err, encrypted) {
+    if (err) return callback(err);
+    
+    encrypted = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
+    callback(null, utils.removeWhitespace(encrypted));
+  });
+}; 
+

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -1,11 +1,11 @@
 
 var utils = require('./utils'),
-    Parser = require('xmldom').DOMParser,
-    SignedXml = require('xml-crypto').SignedXml,
-    xmlenc = require('xml-encryption'),
-    moment = require('moment'),
-    xmlNameValidator = require('xml-name-validator'),
-    is_uri = require('valid-url').is_uri;
+  Parser = require('xmldom').DOMParser,
+  SignedXml = require('xml-crypto').SignedXml,
+  xmlenc = require('xml-encryption'),
+  moment = require('moment'),
+  xmlNameValidator = require('xml-name-validator'),
+  is_uri = require('valid-url').is_uri;
 
 var fs = require('fs');
 var path = require('path');
@@ -16,7 +16,7 @@ var NAMESPACE = 'urn:oasis:names:tc:SAML:2.0:assertion';
 var algorithms = {
   signature: {
     'rsa-sha256': 'http://www.w3.org/2001/04/xmldsig-more#rsa-sha256',
-    'rsa-sha1':  'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
+    'rsa-sha1': 'http://www.w3.org/2000/09/xmldsig#rsa-sha1'
   },
   digest: {
     'sha256': 'http://www.w3.org/2001/04/xmlenc#sha256',
@@ -24,8 +24,8 @@ var algorithms = {
   }
 };
 
-function getAttributeType(value){
-  switch(typeof value) {
+function getAttributeType(value) {
+  switch (typeof value) {
     case "string":
       return 'xs:string';
     case "boolean":
@@ -38,16 +38,16 @@ function getAttributeType(value){
   }
 }
 
-function getNameFormat(name){
-  if (is_uri(name)){
+function getNameFormat(name) {
+  if (is_uri(name)) {
     return 'urn:oasis:names:tc:SAML:2.0:attrname-format:uri';
   }
 
   //  Check that the name is a valid xs:Name -> https://www.w3.org/TR/xmlschema-2/#Name
-  //  xmlNameValidate.name takes a string and will return an object of the form { success, error }, 
-  //  where success is a boolean 
+  //  xmlNameValidate.name takes a string and will return an object of the form { success, error },
+  //  where success is a boolean
   //  if it is false, then error is a string containing some hint as to where the match went wrong.
-  if (xmlNameValidator.name(name).success){
+  if (xmlNameValidator.name(name).success) {
     return 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic';
   }
 
@@ -55,32 +55,59 @@ function getNameFormat(name){
   return 'urn:oasis:names:tc:SAML:2.0:attrname-format:unspecified';
 }
 
-exports.create = function(options, callback) {
-  if (!options.key)
-    throw new Error('Expect a private key in pem format');
+/**
+* Gets the complere SAML Response merged with assertion (encrypted optional) and uses the
+* saml20 argument options to set parts of the response utilizing the saml20Response.template file.
+* @param assertion - the SAML assertion to add to the SAML response.
+* @param options - The saml20 class options argument.
+*/
+function getSamlResponseXml(assertion, options) {
+  var issueTime = new Date().toISOString();
 
-  if (!options.cert)
-    throw new Error('Expect a public key cert in pem format');
+  var assertionXml = new Parser().parseFromString(assertion);
+  var saml20Response = fs.readFileSync(path.join(__dirname, 'saml20Response.template')).toString();
 
-  options.signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
-  options.digestAlgorithm = options.digestAlgorithm || 'sha256';
+  var doc = new Parser().parseFromString(saml20Response.toString());
 
-  options.includeAttributeNameFormat = (typeof options.includeAttributeNameFormat !== 'undefined') ? options.includeAttributeNameFormat : true;
-  options.typedAttributes = (typeof options.typedAttributes !== 'undefined') ? options.typedAttributes : true;
+  doc.documentElement.setAttribute('ID', '_' + (options.uid || utils.uid(32)));
+  doc.documentElement.setAttribute('IssueInstant', moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
+  doc.documentElement.setAttribute('Destination', options.destination);
+  if (options.issuer) {
+    var issuer = doc.documentElement.getElementsByTagName('saml:Issuer');
+    issuer[0].textContent = options.issuer;
+  }
+  doc.lastChild.appendChild(assertionXml.documentElement);
 
+  return doc.toString();
+}
+
+/**
+* Signs the SAML XML at the Assertion level (default) or the Response Level (optional) using private key and cert.
+* @param xmlToSign - The XML in string form containing the XML assertion or response.
+* @param options - The saml20 class options argument.
+*/
+function signXml(xmlToSign, options) {
   // 0.10.1 added prefix, but we want to name it signatureNamespacePrefix - This is just to keep supporting prefix
   options.signatureNamespacePrefix = options.signatureNamespacePrefix || options.prefix;
-  options.signatureNamespacePrefix = typeof options.signatureNamespacePrefix === 'string' ? options.signatureNamespacePrefix : '' ; 
+  options.signatureNamespacePrefix = typeof options.signatureNamespacePrefix === 'string' ? options.signatureNamespacePrefix : '';
 
   var cert = utils.pemToCert(options.cert);
-
   var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[options.signatureAlgorithm], idAttribute: 'ID' });
-  sig.addReference("//*[local-name(.)='Assertion']",
-                  ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
-                  algorithms.digest[options.digestAlgorithm]);
+  var signingLocation = options.createSignedSamlResponse ? 'Response' : 'Assertion';
+  sig.addReference("//*[local-name(.)='" + signingLocation + "']",
+    ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
+    algorithms.digest[options.digestAlgorithm]);
 
   sig.signingKey = options.key;
-  
+
+  var opts = {
+    location: {
+      reference: options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']",
+      action: 'after'
+    },
+    prefix: options.signatureNamespacePrefix
+  };
+
   sig.keyInfoProvider = {
     getKeyInfo: function (key, prefix) {
       prefix = prefix ? prefix + ':' : prefix;
@@ -88,10 +115,53 @@ exports.create = function(options, callback) {
     }
   };
 
+  sig.computeSignature(xmlToSign, opts);
+
+  return sig.getSignedXml();
+}
+
+/**
+* Encrypts s SAML assertion and formats with EncryptedAssertion wrapper using with provided cert.
+* @param assertionToEncrypt - The SAML assertion to encrypt.
+* @param options - The saml20 class options argument.
+* @param callback - The callback function for ASYNC processing completion.
+*/
+function encryptAssertionXml(assertionToEncrypt, options, callback) {
+  var encryptOptions = {
+    rsa_pub: options.encryptionPublicKey,
+    pem: options.encryptionCert,
+    encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
+    keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
+  };
+
+  xmlenc.encrypt(assertionToEncrypt, encryptOptions, function (err, encrypted) {
+    if (err) return callback(err);
+    var assertion = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
+    return callback(null, assertion);
+  })
+}
+
+exports.create = function (options, callback) {
+  if (!options.key)
+    throw new Error('Expect a private key in pem format');
+
+  if (!options.cert)
+    throw new Error('Expect a public key cert in pem format');
+
+  if (options.createSignedSamlResponse &&
+       (!options.destination || options.destination.length < 1))
+    throw new Error('Expect a SAML Response destination for message to be valid.')
+
+  options.signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
+  options.digestAlgorithm = options.digestAlgorithm || 'sha256';
+
+  options.includeAttributeNameFormat = (typeof options.includeAttributeNameFormat !== 'undefined') ? options.includeAttributeNameFormat : true;
+  options.typedAttributes = (typeof options.typedAttributes !== 'undefined') ? options.typedAttributes : true;
+
   var doc;
   try {
     doc = new Parser().parseFromString(saml20.toString());
-  } catch(err){
+  } catch (err) {
     return utils.reportError(err, callback);
   }
 
@@ -109,10 +179,10 @@ exports.create = function(options, callback) {
   if (options.lifetimeInSeconds) {
     conditions[0].setAttribute('NotBefore', now.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
     conditions[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
-  
-    confirmationData[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));  
+
+    confirmationData[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   }
-  
+
   if (options.audiences) {
     var audienceRestriction = doc.createElementNS(NAMESPACE, 'saml:AudienceRestriction');
     var audiences = options.audiences instanceof Array ? options.audiences : [options.audiences];
@@ -122,7 +192,7 @@ exports.create = function(options, callback) {
       audienceRestriction.appendChild(element);
     });
 
-    conditions[0].appendChild(audienceRestriction); 
+    conditions[0].appendChild(audienceRestriction);
   }
 
   if (options.recipient)
@@ -136,16 +206,16 @@ exports.create = function(options, callback) {
     statement.setAttribute('xmlns:xs', 'http://www.w3.org/2001/XMLSchema');
     statement.setAttribute('xmlns:xsi', 'http://www.w3.org/2001/XMLSchema-instance');
     doc.documentElement.appendChild(statement);
-    Object.keys(options.attributes).forEach(function(prop) {
-      if(typeof options.attributes[prop] === 'undefined') return;
+    Object.keys(options.attributes).forEach(function (prop) {
+      if (typeof options.attributes[prop] === 'undefined') return;
       // <saml:Attribute AttributeName="name" AttributeNamespace="http://schemas.xmlsoap.org/claims/identity">
       //    <saml:AttributeValue>Foo Bar</saml:AttributeValue>
       // </saml:Attribute>
       var attributeElement = doc.createElementNS(NAMESPACE, 'saml:Attribute');
       attributeElement.setAttribute('Name', prop);
 
-      if (options.includeAttributeNameFormat){
-        attributeElement.setAttribute('NameFormat', getNameFormat(prop));        
+      if (options.includeAttributeNameFormat) {
+        attributeElement.setAttribute('NameFormat', getNameFormat(prop));
       }
 
       var values = options.attributes[prop] instanceof Array ? options.attributes[prop] : [options.attributes[prop]];
@@ -160,7 +230,7 @@ exports.create = function(options, callback) {
         }
       });
 
-      if (values && values.filter(function(i){ return typeof i !== 'undefined'; }).length > 0) {
+      if (values && values.filter(function (i) { return typeof i !== 'undefined'; }).length > 0) {
         // saml:Attribute must have at least one saml:AttributeValue
         statement.appendChild(attributeElement);
       }
@@ -176,7 +246,7 @@ exports.create = function(options, callback) {
   }
 
   var nameID = doc.documentElement.getElementsByTagNameNS(NAMESPACE, 'NameID')[0];
-  
+
   if (options.nameIdentifier) {
     nameID.textContent = options.nameIdentifier;
   }
@@ -184,48 +254,55 @@ exports.create = function(options, callback) {
   if (options.nameIdentifierFormat) {
     nameID.setAttribute('Format', options.nameIdentifierFormat);
   }
-  
-  if( options.authnContextClassRef ) {
+
+  if (options.authnContextClassRef) {
     var authnCtxClassRef = doc.getElementsByTagName('saml:AuthnContextClassRef')[0];
     authnCtxClassRef.textContent = options.authnContextClassRef;
   }
 
-  var token = utils.removeWhitespace(doc.toString());
-  var signed;
-  try {
-    var opts = { 
-      location: { 
-        reference: options.xpathToNodeBeforeSignature || "//*[local-name(.)='Issuer']", 
-        action: 'after'
-      },
-      prefix: options.signatureNamespacePrefix
-    };
-    
-    sig.computeSignature(token, opts);
-    signed = sig.getSignedXml();
-  } catch(err){
-    return utils.reportError(err, callback);
+  var assertion = utils.removeWhitespace(doc.toString());
+
+  // NEW: Option: build a complete signed SAML response with embedded (option encrypted) assertion
+  if (options.createSignedSamlResponse) {
+    try {
+      // IF SAML response assertion is set to be encrypted
+      if (options.encryptionCert) {
+        encryptAssertionXml(assertion, options, function (err, encryptedAssertion) {
+          if (err) return callback(err);
+          var signedResponse = signSamlResponse(encryptedAssertion);
+          return callback(null, signedResponse);
+        });
+      } else {
+        // Do not encrypt assertion and send back
+        var signedPlainResponse = signSamlResponse(assertion);
+        return (callback) ? callback(null, signedPlainResponse) : signedPlainResponse;
+      }
+    } catch (err) {
+      return (callback) ? callback(err) : err;
+    }
+  } else {
+    try {
+      // Sign the assertion always for both options
+      var signedAssertion = signXml(utils.removeWhitespace(assertion), options);
+      if (options.encryptionCert) {
+        // If assertion is set to be encrypted
+        encryptAssertionXml(signedAssertion, options, function (err, encryptedAssertion) {
+          if (err) return callback(err);
+          return callback(null, encryptedAssertion)
+        });
+      } else {
+        // If assertion encryption not set just send back
+        return (callback) ? callback(null, signedAssertion) : signedAssertion;
+      }
+    } catch (err) {
+      return (callback) ? callback(err) : err;
+    }
   }
 
-  if (!options.encryptionCert) {
-    if (callback) 
-      return callback(null, signed);
-    else 
-      return signed;
+  // Generates response with inserted assertion (or encrypted assertion) and signs
+  function signSamlResponse(assertion) {
+    var samlResponse = getSamlResponseXml(assertion, options);
+    return signXml(utils.removeWhitespace(samlResponse), options);
   }
 
-
-  var encryptOptions = {
-    rsa_pub: options.encryptionPublicKey,
-    pem: options.encryptionCert,
-    encryptionAlgorithm: options.encryptionAlgorithm || 'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
-    keyEncryptionAlgorighm: options.keyEncryptionAlgorighm || 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p'
-  };
-
-  xmlenc.encrypt(signed, encryptOptions, function(err, encrypted) {
-    if (err) return callback(err);
-    encrypted = '<saml:EncryptedAssertion xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion">' + encrypted + '</saml:EncryptedAssertion>';
-    callback(null, utils.removeWhitespace(encrypted));
-  });
-}; 
-
+};

--- a/lib/saml20Response.template
+++ b/lib/saml20Response.template
@@ -1,0 +1,6 @@
+  <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" IssueInstant="" ID="" Destination="">
+    <saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity"></saml:Issuer>
+    <samlp:Status>
+      <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+    </samlp:Status>
+  </samlp:Response>

--- a/lib/saml20Response.template
+++ b/lib/saml20Response.template
@@ -1,6 +1,6 @@
   <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" IssueInstant="" ID="" Destination="">
     <saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity"></saml:Issuer>
     <samlp:Status>
-      <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
+      <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
     </samlp:Status>
   </samlp:Response>

--- a/lib/saml20Response.template
+++ b/lib/saml20Response.template
@@ -1,6 +1,6 @@
   <samlp:Response xmlns:samlp="urn:oasis:names:tc:SAML:2.0:protocol" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" Version="2.0" IssueInstant="" ID="" Destination="">
     <saml:Issuer Format="urn:oasis:names:tc:SAML:2.0:nameid-format:entity"></saml:Issuer>
     <samlp:Status>
-      <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success" />
+      <samlp:StatusCode Value="urn:oasis:names:tc:SAML:2.0:status:Success"/>
     </samlp:Status>
   </samlp:Response>

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -484,7 +484,7 @@ describe('saml 2.0', function () {
     assert.equal(attributeStatement.length, 0);
   });
 
-  describe('saml 2.0 test full SAML response', function () {
+  describe('saml 2.0 full SAML response', function () {
 
     it('should create a saml 2.0 signed response including plain assertion', function (done) {
       var options = {

--- a/test/saml20.tests.js
+++ b/test/saml20.tests.js
@@ -484,7 +484,7 @@ describe('saml 2.0', function () {
     assert.equal(attributeStatement.length, 0);
   });
 
-  describe('saml 2.0 full SAML response', function () {
+  describe('saml 2.0 test full SAML response', function () {
 
     it('should create a saml 2.0 signed response including plain assertion', function (done) {
       var options = {

--- a/test/utils.js
+++ b/test/utils.js
@@ -94,5 +94,11 @@ exports.getSubjectConfirmation = function(assertion) {
 exports.getEncryptedData = function(encryptedAssertion) {
   var doc = new xmldom.DOMParser().parseFromString(encryptedAssertion);
   return doc.documentElement
-            .getElementsByTagName('xenc:EncryptedData')[0];
+            .getElementsByTagName('xenc:EncryptedData')[0];            
 };
+
+exports.getResponseData = function(assertion) {
+  var doc = new xmldom.DOMParser().parseFromString(assertion);
+  return doc.getElementsByTagName('samlp:Response')[0];
+};
+

--- a/test/utils.js
+++ b/test/utils.js
@@ -97,7 +97,7 @@ exports.getEncryptedData = function(encryptedAssertion) {
             .getElementsByTagName('xenc:EncryptedData')[0];            
 };
 
-exports.getResponseData = function(samlResponse) {
-  var doc = new xmldom.DOMParser().parseFromString(samlResponse);
+exports.getResponseData = function(assertion) {
+  var doc = new xmldom.DOMParser().parseFromString(assertion);
   return doc.getElementsByTagName('samlp:Response')[0];
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -97,8 +97,7 @@ exports.getEncryptedData = function(encryptedAssertion) {
             .getElementsByTagName('xenc:EncryptedData')[0];            
 };
 
-exports.getResponseData = function(assertion) {
-  var doc = new xmldom.DOMParser().parseFromString(assertion);
+exports.getResponseData = function(samlResponse) {
+  var doc = new xmldom.DOMParser().parseFromString(samlResponse);
   return doc.getElementsByTagName('samlp:Response')[0];
 };
-


### PR DESCRIPTION
Reason for Feature Addition:
The current node-saml allows for:
1. creating an assertion that may or may not have attributes
2. Sign assertion with  private key/public cert
3. Option to encrypt it with a 3rd party public cert

Feature enhancement allows for a new Full SAML 2.0 Response:
1. creating an assertion that may or may not have attributes
2. Option to encrypt assertion with a 3rd party public cert
3. Add assertion to a SAML 2.0 response
4. Sign SAML 2.0 response with private key/public cert

This is accomplished by using an optional switch for 100% backward compatibility:
options.createSignedSamlResponse
 
If this switch is active, an additional options check is performed on insuring a second new option, destination is included. 

The very important SAML response document id is derived from (options.uid || utils.uid(32))
so when the SAML is signed the 'ID' aligns with the reference 'URI'.

Unit tests were also updated to insure compatibility with existing code tests.
All additional test +:
    saml 2.0 full SAML response
      ✓ should create a saml 2.0 signed response including plain assertion
      ✓ ...with attributes
      ✓ should insure SAML response attribute [ID] matches signature reference attribute [URI]
      ✓ should require a [Destination] attribute on SAML Response element

      encryption full SAML response
        ✓ should create a saml 2.0 signed response including encrypted assertion (41ms)
        ✓ ...with assertion attributes (41ms)

Ready for review.  In addition, this code update was moved back and forth between node-sso-formatter to insure all unit test and e2e tests were successful.

Svet and Brian also assisted in this work.
Thank you.

Any questions: Jon Lindsey

