### PR TITLE
Enhance signing node saml

### DIFF
--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -81,7 +81,6 @@ function getSamlResponseXml(assertion, options) {
 
   var doc = new Parser().parseFromString(saml20Response.toString());
 
-  // doc.documentElement.setAttribute('ID', '_' + (options.uid || utils.uid(32)));
   doc.documentElement.setAttribute('ID', '_' + (options.responseUid));
   doc.documentElement.setAttribute('IssueInstant', moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   doc.documentElement.setAttribute('Destination', options.destination);

--- a/lib/saml20.js
+++ b/lib/saml20.js
@@ -10,6 +10,7 @@ var utils = require('./utils'),
 var fs = require('fs');
 var path = require('path');
 var saml20 = fs.readFileSync(path.join(__dirname, 'saml20.template')).toString();
+var documentSigningLocation = 'Assertion';
 
 var NAMESPACE = 'urn:oasis:names:tc:SAML:2.0:assertion';
 
@@ -23,6 +24,11 @@ var algorithms = {
     'sha1': 'http://www.w3.org/2000/09/xmldsig#sha1'
   }
 };
+
+var ResponseSigningLevel = {
+  ResponseOnly: 'ResponseOnly',
+  AssertionAndResponse: 'AssertionAndResponse'
+}
 
 function getAttributeType(value){
   switch(typeof value) {
@@ -44,8 +50,8 @@ function getNameFormat(name){
   }
 
   //  Check that the name is a valid xs:Name -> https://www.w3.org/TR/xmlschema-2/#Name
-  //  xmlNameValidate.name takes a string and will return an object of the form { success, error }, 
-  //  where success is a boolean 
+  //  xmlNameValidate.name takes a string and will return an object of the form { success, error },
+  //  where success is a boolean
   //  if it is false, then error is a string containing some hint as to where the match went wrong.
   if (xmlNameValidator.name(name).success){
     return 'urn:oasis:names:tc:SAML:2.0:attrname-format:basic';
@@ -56,7 +62,7 @@ function getNameFormat(name){
 }
 
 /**
-* Gets the complete SAML20 response embedding the assertion (encrypted optional) and 
+* Gets the complete SAML20 response embedding the assertion (encrypted optional) and
 * options argument to set attributes for response utilizing the saml20Response.template file.
 * @param assertion - the SAML assertion to add to the SAML response.
 * @param options - The saml20 class options argument.
@@ -75,7 +81,8 @@ function getSamlResponseXml(assertion, options) {
 
   var doc = new Parser().parseFromString(saml20Response.toString());
 
-  doc.documentElement.setAttribute('ID', '_' + (options.uid || utils.uid(32)));
+  // doc.documentElement.setAttribute('ID', '_' + (options.uid || utils.uid(32)));
+  doc.documentElement.setAttribute('ID', '_' + (options.responseUid));
   doc.documentElement.setAttribute('IssueInstant', moment.utc().format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   doc.documentElement.setAttribute('Destination', options.destination);
   if (options.issuer) {
@@ -94,18 +101,19 @@ function getSamlResponseXml(assertion, options) {
 * @returns string - Signed SAML assertion or response depending on option.
 * @throws ReferenceError if xml argument sent for signing is null or empty.
 */
-function signXml(xmlToSign, options) {
+function signXml(xmlToSign, options, documentSigningLocation) {
 
   if (!xmlToSign || xmlToSign.length < 1)
     throw new ReferenceError('XML to sign cannot be null or empty.')
 
   // 0.10.1 added prefix, but we want to name it signatureNamespacePrefix - This is just to keep supporting prefix
   options.signatureNamespacePrefix = options.signatureNamespacePrefix || options.prefix;
-  options.signatureNamespacePrefix = typeof options.signatureNamespacePrefix === 'string' ? options.signatureNamespacePrefix : '' ; 
+  options.signatureNamespacePrefix = typeof options.signatureNamespacePrefix === 'string' ? options.signatureNamespacePrefix : '' ;
 
   var cert = utils.pemToCert(options.cert);
   var sig = new SignedXml(null, { signatureAlgorithm: algorithms.signature[options.signatureAlgorithm], idAttribute: 'ID' });
-  var signingLocation = options.createSignedSamlResponse ? 'Response' : 'Assertion';
+  var signingLocation = documentSigningLocation || 'Assertion';
+
   sig.addReference("//*[local-name(.)='" + signingLocation + "']",
     ["http://www.w3.org/2000/09/xmldsig#enveloped-signature", "http://www.w3.org/2001/10/xml-exc-c14n#"],
     algorithms.digest[options.digestAlgorithm]);
@@ -126,7 +134,7 @@ function signXml(xmlToSign, options) {
       return "<" + prefix + "X509Data><" + prefix + "X509Certificate>" + cert + "</" + prefix + "X509Certificate></" + prefix + "X509Data>";
     }
   };
-  
+
   sig.computeSignature(xmlToSign, opts);
 
   return sig.getSignedXml();
@@ -162,9 +170,15 @@ exports.create = function (options, callback) {
   if (!options.cert)
     throw new Error('Expect a public key cert in pem format');
 
-  if (options.createSignedSamlResponse &&
-       (!options.destination || options.destination.length < 1))
-    throw new Error('Expect a SAML Response destination for message to be valid.')
+  if (options.createSignedSamlResponse) {
+
+    if (!options.destination || options.destination.length < 1) {
+      throw new Error('Expect a SAML Response destination for message to be valid.');
+    }
+
+    options.responseSigningLevel = options.responseSigningLevel || ResponseSigningLevel.ResponseOnly;
+    options.responseUid = options.responseUid || utils.uid(32);
+  }
 
   options.signatureAlgorithm = options.signatureAlgorithm || 'rsa-sha256';
   options.digestAlgorithm = options.digestAlgorithm || 'sha256';
@@ -193,10 +207,10 @@ exports.create = function (options, callback) {
   if (options.lifetimeInSeconds) {
     conditions[0].setAttribute('NotBefore', now.format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
     conditions[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
-  
-    confirmationData[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));  
+
+    confirmationData[0].setAttribute('NotOnOrAfter', now.clone().add(options.lifetimeInSeconds, 'seconds').format('YYYY-MM-DDTHH:mm:ss.SSS[Z]'));
   }
-  
+
   if (options.audiences) {
     var audienceRestriction = doc.createElementNS(NAMESPACE, 'saml:AudienceRestriction');
     var audiences = options.audiences instanceof Array ? options.audiences : [options.audiences];
@@ -206,7 +220,7 @@ exports.create = function (options, callback) {
       audienceRestriction.appendChild(element);
     });
 
-    conditions[0].appendChild(audienceRestriction); 
+    conditions[0].appendChild(audienceRestriction);
   }
 
   if (options.recipient)
@@ -229,7 +243,7 @@ exports.create = function (options, callback) {
       attributeElement.setAttribute('Name', prop);
 
       if (options.includeAttributeNameFormat){
-        attributeElement.setAttribute('NameFormat', getNameFormat(prop));        
+        attributeElement.setAttribute('NameFormat', getNameFormat(prop));
       }
 
       var values = options.attributes[prop] instanceof Array ? options.attributes[prop] : [options.attributes[prop]];
@@ -260,7 +274,7 @@ exports.create = function (options, callback) {
   }
 
   var nameID = doc.documentElement.getElementsByTagNameNS(NAMESPACE, 'NameID')[0];
-  
+
   if (options.nameIdentifier) {
     nameID.textContent = options.nameIdentifier;
   }
@@ -276,21 +290,24 @@ exports.create = function (options, callback) {
 
   var assertion = utils.removeWhitespace(doc.toString());
 
-  // NEW: construct a SAML20 response signed at the response with embedded (encrypted option) assertion
+  // Enhanced path - construct a SAML20 response signed at the response
+  // with embedded (encrypted option) (signed option) assertion
   if (options.createSignedSamlResponse) {
+    if (options.responseSigningLevel === ResponseSigningLevel.AssertionAndResponse) {
+      assertion = signXml(utils.removeWhitespace(assertion), options, 'Assertion');
+    } 
 
     if (options.encryptionCert) {
       encryptAssertionXml(assertion, options)
       .then(encryptedAssertion => (callback(null, signSamlResponse(encryptedAssertion))))
       .catch((err) => callback(err));
     } else {
-      // Send saml response back signed if not set for encryption
       var signedPlainResponse = signSamlResponse(assertion);
       return (callback) ? callback(null, signedPlainResponse) : signedPlainResponse;
     }
+  // Original path - create a simple signed (encrypted option) assertion.
   } else {
-    // Sign the assertion always for both options
-    var signedAssertion = signXml(utils.removeWhitespace(assertion), options);
+    var signedAssertion = signXml(utils.removeWhitespace(assertion), options, 'Assertion');
 
     if (options.encryptionCert) {
       encryptAssertionXml(signedAssertion, options)
@@ -305,6 +322,7 @@ exports.create = function (options, callback) {
   // Sign response with inserted assertion (or encrypted assertion)
   function signSamlResponse(assertion) {
     var samlResponse = getSamlResponseXml(assertion, options);
-    return signXml(utils.removeWhitespace(samlResponse), options);
+    return signXml(utils.removeWhitespace(samlResponse), options, 'Response');
   }
+
 };

--- a/test/utils.js
+++ b/test/utils.js
@@ -18,6 +18,24 @@ exports.isValidSignature = function(assertion, cert) {
   return sig.checkSignature(assertion);
 };
 
+exports.isValidResponseSignature = function(response, cert) {
+   var doc = new xmldom.DOMParser().parseFromString(response);
+  var signature = doc.documentElement
+  .getElementsByTagName('Signature')[0]
+
+  var sig = new xmlCrypto.SignedXml(null, { idAttribute: 'ResponseID' });
+  sig.keyInfoProvider = {
+    getKeyInfo: function (key) {
+      return "<X509Data></X509Data>";
+    },
+    getKey: function (keyInfo) {
+      return cert;
+    }
+  };
+  sig.loadSignature(signature.toString());
+  return sig.checkSignature(response);
+};
+
 exports.getIssuer = function(assertion) {
   var doc = new xmldom.DOMParser().parseFromString(assertion);
   return doc.documentElement.getAttribute('Issuer');


### PR DESCRIPTION
feat: Add ability to sign both the SAML response and Assertion by setting
        Add the ability to control IDs of the Response and Assertion for SAML 20 XSD compliance.
        Create automatic failsafe values for Response and Assertion IDs to be SAML 20 XSD compliant.

With this feature the following modes are possible
Original
SAML 20 signed assertion
SAML 20 encrypted signed assertion

Previous
SAML 20 signed response with assertion
SAML 20 signed response with encrypted assertion

New
SAML 20 signed response with signed assertion
SAML 20 signed response with encrypted signed assertion

This should finally cover it.

**Testing:**  Mocha - 2 additional unit tests were added to check for valid signature in the response and assertion with attribute option.  In addition, all output products for all modes were tested against https://www.samltool.com/validate_response.php

All node-sso-formatter unit and e2e tests were verified, and all new functionality is additive with 100% backward compatibility.




       